### PR TITLE
Snippet directive is disabled in recent ingress controller versions

### DIFF
--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -5,9 +5,3 @@ wordpress:
   ingress:
     enabled: true
     hostname: sslip.io
-    annotations:
-      # https://github.com/bitnami/charts/issues/2111
-      nginx.ingress.kubernetes.io/configuration-snippet: |
-        location ~ /wp-admin$ {
-             return 301 /wp-admin/;
-         }


### PR DESCRIPTION
Using the snippet directive in the ingress resource annotation doesn't work with the recent ingress controller version unless snippets are specifically allowed by modifying the cluster YAML.

https://github.com/rancher/rancher/issues/35128

Instead of having users mess with cluster YAML options it's proably better to just ask them to use a trailing slash with accessing `/wp-admin/` URL.